### PR TITLE
Fix php notice in the widget

### DIFF
--- a/accordion-archive-widget.php
+++ b/accordion-archive-widget.php
@@ -89,7 +89,7 @@ class WP_Widget_Accordion_Archives extends WP_Widget {
 			foreach ($archives as $archive) {
 
 				$archive = explode(' ', $archive);
-				if ($archive[1] == $year) {
+				if (!empty($archive[1]) && $archive[1] == $year) {
 					echo '<li class="archive-accordion-month"><a href="' . 
 					// Get the archive link
 					get_month_link($year, date("m", strtotime($archive[0] . '-' . $year))) . 


### PR DESCRIPTION
At the end of each accordion, the following notice shows up:

Notice: Undefined offset: 1 in .../accordion-archive-widget/accordion-archive-widget.php on line 92

This pull request fixes it. :)
